### PR TITLE
Update for 64bit user IDs

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -508,7 +508,11 @@ Twitter.prototype.showUser = function(id, callback) {
 	var url = '/users/show.json';
 
 	var params = {};
-	if (typeof id === 'string')
+
+	if (typeof id === 'object') {
+		params = id;
+	}
+	else if (typeof id === 'string')
 		params.screen_name = id;
 	else
 		params.user_id = id;
@@ -600,12 +604,17 @@ Twitter.prototype.getLists = function(id, params, callback) {
 	}
 
 	var defaults = {key:'lists'};
-	if (typeof id === 'string')
+
+	if (typeof id === 'object') {
+		params = id;
+	}
+	else if (typeof id === 'string')
 		defaults.screen_name = id;
 	else
 		defaults.user_id = id;
-	params = merge(defaults, params);
 
+	params = merge(defaults, params);
+console.log(params);
 	var url = '/lists.json';
 	this._getUsingCursor(url, params, callback);
 	return this;
@@ -618,7 +627,11 @@ Twitter.prototype.getListMemberships = function(id, params, callback) {
 	}
 
 	var defaults = {key:'lists'};
-	if (typeof id === 'string')
+
+	if (typeof id === 'object') {
+		params = id;
+	}
+	else if (typeof id === 'string')
 		defaults.screen_name = id;
 	else
 		defaults.user_id = id;
@@ -636,7 +649,10 @@ Twitter.prototype.getListSubscriptions = function(id, params, callback) {
 	}
 
 	var defaults = {key:'lists'};
-	if (typeof id === 'string')
+	if (typeof id === 'object') {
+		params = id;
+	}
+	else if (typeof id === 'string')
 		defaults.screen_name = id;
 	else
 		defaults.user_id = id;
@@ -752,7 +768,10 @@ Twitter.prototype.newDirectMessage = function(id, text, params, callback) {
 		text: text,
 		include_entities: 1
 	};
-	if (typeof id === 'string')
+	if (typeof id === 'object') {
+		params = id;
+	}
+	else if (typeof id === 'string')
 		defaults.screen_name = id;
 	else
 		defaults.user_id = id;
@@ -785,7 +804,10 @@ Twitter.prototype.createFriendship = function(id, params, callback) {
 	var defaults = {
 		include_entities: 1
 	};
-	if (typeof id === 'string')
+	if (typeof id === 'object') {
+		params = id;
+	}
+	else if (typeof id === 'string')
 		defaults.screen_name = id;
 	else
 		defaults.user_id = id;
@@ -805,7 +827,10 @@ Twitter.prototype.destroyFriendship = function(id, callback) {
 	var params = {
 		include_entities: 1
 	};
-	if (typeof id === 'string')
+	if (typeof id === 'object') {
+		params = id;
+	}
+	else if (typeof id === 'string')
 		params.screen_name = id;
 	else
 		params.user_id = id;
@@ -822,12 +847,22 @@ Twitter.prototype.deleteFriendship
 Twitter.prototype.showFriendship = function(source, target, callback) {
 	var params = {};
 
-	if (typeof source === 'string')
+	if (typeof source === 'object') {
+		for(var source_property in source) {
+			params[source_property] = source[source_property];
+		}
+	}
+	else if (typeof source === 'string')
 		params.source_screen_name = source;
 	else
 		params.source_id = source;
 
-	if (typeof target === 'string')
+	if (typeof target === 'object') {
+		for(var target_property in target) {
+			params[target_property] = target[target_property];
+		}
+	}
+	else if (typeof target === 'string')
 		params.target_screen_name = target;
 	else
 		params.target_id = target;
@@ -860,12 +895,16 @@ Twitter.prototype.getFriendsIds = function(id, callback) {
 		callback = id;
 		id = null;
 	}
-
-	var params = { key: 'ids' };
-	if (typeof id === 'string')
+	var params = {};
+	if (typeof id === 'object') {
+		params = id;
+	}
+	else if (typeof id === 'string')
 		params.screen_name = id;
 	else if (typeof id === 'number')
 		params.user_id = id;
+
+	params.key = 'ids';
 
 	var url = '/friends/ids.json';
 	this._getUsingCursor(url, params, callback);
@@ -878,11 +917,17 @@ Twitter.prototype.getFollowersIds = function(id, callback) {
 		id = null;
 	}
 
-	var params = { key: 'ids' };
-	if (typeof id === 'string')
+	var params = {};
+
+	if (typeof id === 'object') {
+		params = id;
+	}
+	else if (typeof id === 'string')
 		params.screen_name = id;
 	else if (typeof id === 'number')
 		params.user_id = id;
+
+	params.key = 'ids';
 
 	var url = '/followers/ids.json';
 	this._getUsingCursor(url, params, callback);
@@ -949,7 +994,10 @@ Twitter.prototype.createBlock = function(id, callback) {
 	var url = '/blocks/create.json';
 
 	var params = {};
-	if (typeof id === 'string')
+	if (typeof id === 'object') {
+		params = id;
+	}
+	else if (typeof id === 'string')
 		params.screen_name = id;
 	else
 		params.user_id = id;
@@ -964,7 +1012,10 @@ Twitter.prototype.destroyBlock = function(id, callback) {
 	var url = '/blocks/destroy.json';
 
 	var params = {};
-	if (typeof id === 'string')
+	if (typeof id === 'object') {
+		params = id;
+	}
+	else if (typeof id === 'string')
 		params.screen_name = id;
 	else
 		params.user_id = id;
@@ -979,7 +1030,10 @@ Twitter.prototype.blockExists = function(id, callback) {
 	var url = '/blocks/exists.json';
 
 	var params = {};
-	if (typeof id === 'string')
+	if (typeof id === 'object') {
+		params = id;
+	}
+	else if (typeof id === 'string')
 		params.screen_name = id;
 	else
 		params.user_id = id;
@@ -998,7 +1052,10 @@ Twitter.prototype.reportSpam = function(id, callback) {
 	var url = '/report_spam.json';
 
 	var params = {};
-	if (typeof id === 'string')
+	if (typeof id === 'object') {
+		params = id;
+	}
+	else if (typeof id === 'string')
 		params.screen_name = id;
 	else
 		params.user_id = id;


### PR DESCRIPTION
In order to support 64bit user IDs, you'll need to store IDs as strings, causing ssumptions like this will fail:

``` javascript
    if (typeof id === 'string')
        params.screen_name = id;
    else
        params.user_id = id;
```
