### PR TITLE
Added filter stream support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The stream() callback receives a Stream-like EventEmitter:
 		});
 	});
 
-node-twitter also supports user and site streams:
+node-twitter also supports user, filter and site streams:
 
 	twit.stream('user', {track:'nodejs'}, function(stream) {
 		stream.on('data', function(data) {

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -45,6 +45,7 @@ function Twitter(options) {
 		search_base: 'https://api.twitter.com/1.1/search',
 		user_stream_base: 'https://userstream.twitter.com/1.1',
 		site_stream_base: 'https://sitestream.twitter.com/1.1',
+		filter_stream_base: 'https://stream.twitter.com/1.1/statuses',
 
 		secure: false, // force use of https for login/gatekeeper
 		cookie: 'twauth',
@@ -211,6 +212,12 @@ Twitter.prototype.stream = function(method, params, callback) {
 		// Workaround for node-oauth vs. twitter double-encode-commas bug
 		if ( params && params.follow && Array.isArray(params.follow) ) {
 			params.follow = params.follow.join(',')
+		}
+	} else if (method === 'filter') {
+		stream_base = this.options.filter_stream_base;
+		// Workaround for node-oauth vs. twitter commas-in-params bug
+		if ( params && params.track && Array.isArray(params.track) ) {
+			params.track = params.track.join(',')
 		}
 	}
 


### PR DESCRIPTION
I've added in the option to stream filtered public statuses using the
'filter' section of the Streaming API
(https://dev.twitter.com/docs/api/1.1/post/statuses/filter).
