### PR TITLE
Fix twitter get if no url posted without first character /

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -88,6 +88,8 @@ Twitter.prototype.get = function(url, params, callback) {
 
 	if (url.charAt(0) == '/')
 		url = this.options.rest_base + url;
+	else
+		url = this.options.rest_base + '/' + url;
 
 	this.oauth.get(url + '?' + querystring.stringify(params),
 		this.options.access_token_key,


### PR DESCRIPTION
I think this is good tone for users. because not any time you copy paste exact url.
Framework need create request or throw readable exception
