### PR TITLE
Store access token after successful auth

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -323,6 +323,9 @@ Twitter.prototype.login = function(mount, success) {
 					// FIXME: do something more intelligent
 					return next(500);
 				} else {
+					// store access token
+					self.options.access_token_key = twauth.access_token_key;
+ 					self.options.access_token_secret = twauth.access_token_secret;
 					cookies.set(self.options.cookie, JSON.stringify({
 						user_id: user_id,
 						screen_name: screen_name,
@@ -379,21 +382,24 @@ Twitter.prototype.gatekeeper = function(options) {
 		var twauth = self.cookie(req);
 
 		// We have a winner
-		if ( twauth && twauth.user_id && twauth.access_token_secret )
+		if ( twauth && twauth.user_id && twauth.access_token_secret ) {
+			self.options.access_token_key = twauth.access_token_key;
+ 			self.options.access_token_secret = twauth.access_token_secret;
 			return next();
+		}
 
-        if (options.failureRedirect) {
-            res.redirect(options.failureRedirect);
-        } else {
-            res.writeHead(401, {}); // {} for bug in stack
-            res.end([
-                '<html><head>',
-                '<meta http-equiv="refresh" content="1;url=' + mount + '">',
-                '</head><body>',
-                '<h1>Twitter authentication required.</h1>',
-                '</body></html>'
-            ].join(''));
-        }
+    if (options.failureRedirect) {
+        res.redirect(options.failureRedirect);
+    } else {
+        res.writeHead(401, {}); // {} for bug in stack
+        res.end([
+            '<html><head>',
+            '<meta http-equiv="refresh" content="1;url=' + mount + '">',
+            '</head><body>',
+            '<h1>Twitter authentication required.</h1>',
+            '</body></html>'
+        ].join(''));
+    }
 	};
 }
 


### PR DESCRIPTION
Store access token key & secret in options after auth to allow subsequent signed requests.

Also fixed indentation in gatekeeper.
