### PR TITLE
update rate_limit url to the 1.1 version (this was the v1 url)

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -960,7 +960,7 @@ Twitter.prototype.verifyCredentials = function(callback) {
 }
 
 Twitter.prototype.rateLimitStatus = function(callback) {
-	var url = '/account/rate_limit_status.json';
+	var url = '/application/rate_limit_status.json';
 	this.get(url, null, callback);
 	return this;
 }


### PR DESCRIPTION
The rate_limit call tries to use the v1 url.
V1.1 changed from `/account/rate_limit_status.json` to `/application/rate_limit_status.json`

see : https://dev.twitter.com/docs/api/1.1/get/application/rate_limit_status
