### PR TITLE
Add lookupUsers

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -571,7 +571,6 @@ Twitter.prototype.getRetweetedByIds = function(id, params, callback) {
 // User resources
 
 Twitter.prototype.showUser = function(id, callback) {
-	// FIXME: handle id-array and id-with-commas as lookupUser
 	//  NOTE: params with commas b0rk between node-oauth and twitter
 	//        https://github.com/ciaranj/node-oauth/issues/7
 	var url = '/users/show.json';
@@ -588,9 +587,19 @@ Twitter.prototype.showUser = function(id, callback) {
 
 	this.get(url, params, callback);
 	return this;
-};
+}
+Twitter.prototype.lookupUser = Twitter.prototype.showUser;
 
-Twitter.prototype.lookupUser = Twitter.prototype.lookupUsers = Twitter.prototype.showUser;
+Twitter.prototype.lookupUsers = function(ids, callback) {
+  var url = '/users/lookup.json';
+  
+  var params = {};
+  
+  params.user_id = JSON.stringify(ids);
+  
+  this.get(url, params, callback);
+  return this;
+}
 
 Twitter.prototype.searchUser = function(q, params, callback) {
 	if (typeof params === 'function') {


### PR DESCRIPTION
Hi!

I've added the `lookupUsers` that takes an array of Ids as inputs, and returns the user profiles.
This would solve:  https://github.com/desmondmorris/node-twitter/issues/24

It can be tested with:

```
twit.get('/friends/ids.json', function(r) {
  twit.lookupUsers(r.ids.slice(1,10), function(users) {
    console.log(users)
  });
});
```
