### PR TITLE
Add source parameter to error object

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -81,6 +81,7 @@ Parser.prototype.receive = function receive(buffer) {
             break;
         }
       } catch (error) {
+        error.source = json;
         this.emit('error', error);
       }
     }


### PR DESCRIPTION
Upon errors, sometimes the original message doesn't parse because it's a plain-text response from Twitter.

This is useless to us in that scenario since there isn't really any way of seeing what that error is other than a random syntax error (see #26).

This PR tacks on the original _not-JSON_ response as `source` to the error, without breaking anything.
