### PR TITLE
Explicitly catch SyntaxError from JSON.Parse

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -82,8 +82,8 @@ Parser.prototype.receive = function receive(buffer) {
         }
       } catch (error) {
         if (error.name === 'SyntaxError') {
-        	error.json = json;
-        	this.emit('error', error);
+          error.json = json;
+          this.emit('error', error);
         } else {
           this.emit('error', error);
         }


### PR DESCRIPTION
If it's a syntax error, add the bad json to the message.
This means in cases when twitter returns a string (e.g. "you can't do that, try again later") error.json is populated and so the error can be accessed.
