### PR TITLE
Express 4.0 Compatibility

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -356,7 +356,7 @@ Twitter.prototype.login = function(mount, success) {
 
 		// We have a winner, but they're in the wrong place
 		if ( twauth && twauth.user_id && twauth.access_token_secret ) {
-			res.writeHead(302, {'Location': success || '/'});
+			res.status(302).redirect( success || '/');
 			res.end();
 			return;
 


### PR DESCRIPTION
Express 4.0 changes writeHead's behaviour in such a way that it breaks node-twitter by way of enweirdification of the writeHead function. Haven't had time to investigate properly, but this makes it work for me, does the same thing as the previous line of code, and is back-compatible.
