### PR TITLE
add statusCode for 200 also

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -104,6 +104,7 @@ Twitter.prototype.get = function(url, params, callback) {
 		} else {
 			try {
 				var json = JSON.parse(data);
+				json.statusCode = response.statusCode;
 				callback(json);
 			} catch(err) {
 				callback(err);
@@ -157,6 +158,7 @@ Twitter.prototype.post = function(url, content, content_type, callback) {
 		} else {
 			try {
 				var json = JSON.parse(data);
+				json.statusCode = response.statusCode;
 				callback(json);
 			} catch(err) {
 				callback(err);


### PR DESCRIPTION
@desmondmorris: currently only the callback data of calls with errors have `data.statusCode`.

I would like to be able to check if incoming data is OK by doing

```
if (data.statusCode == 200){
     // do something
```

Cheers!
