### PR TITLE
Pass the response object as argument in callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ You'll need to create the routes for index & login. On the login page, you'll wa
 
 The convenience APIs aren't finished, but you can get started with the basics:
 
-	twit.get('/statuses/show/27593302936.json', {include_entities:true}, function(data) {
-		console.log(util.inspect(data));
+	twit.get('/statuses/show/27593302936.json', {include_entities:true}, function(data, res) {
+		console.log(util.inspect(data), res.statusCode);
 	});
 
 ### REST API (unstable, may change)

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -100,14 +100,13 @@ Twitter.prototype.get = function(url, params, callback) {
 					http.STATUS_CODES[error.statusCode]);
 			err.statusCode = error.statusCode;
 			err.data = error.data;
-			callback(err);
+			callback(err, response);
 		} else {
 			try {
 				var json = JSON.parse(data);
-				json.statusCode = response.statusCode;
-				callback(json);
+				callback(json, response);
 			} catch(err) {
-				callback(err);
+				callback(err, response);
 			}
 		}
 	});
@@ -154,14 +153,13 @@ Twitter.prototype.post = function(url, content, content_type, callback) {
 				  http.STATUS_CODES[error.statusCode]);
 			err.statusCode = error.statusCode;
 			err.data = error.data;
-			callback(err);
+			callback(err, response);
 		} else {
 			try {
 				var json = JSON.parse(data);
-				json.statusCode = response.statusCode;
-				callback(json);
+				callback(json, response);
 			} catch(err) {
-				callback(err);
+				callback(err, response);
 			}
 		}
 	});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "twitter",
-    "version": "v0.2.12",
+    "version": "v0.2.13",
     "description": "Twitter API client library for node.js",
     "keywords": [
         "twitter",


### PR DESCRIPTION
[As suggested](https://github.com/desmondmorris/node-twitter/pull/42#issuecomment-59798965) by @arian the callback could have the object as second argument. 
This way the `statusCode` would be available there and not from the data argument.

Added a version bum and small docs change, in case you agree to this.
