### PR TITLE
Added friendships/lookup endpoint

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -968,7 +968,7 @@ Twitter.prototype.outgoingFriendships = Twitter.prototype.outgoingFriendship;
 Twitter.prototype.lookupFriendship = function(users, callback) {
 	var params = {};
 	// firstly, make sure we're dealing with an array, otherwise this will break
-	if(users.consructor === Array) {
+	if(users.constructor === Array) {
 		for(i = 0; i < users.length; i++) {
 			if(typeof users[i] === "string") {
 				params.screen_name = params.screen_name + ',' + users[i];


### PR DESCRIPTION
Suggested as per #43 (thanks @lukaswhite), implemented here. Example usage: 

``` javascript
client.lookupFriendships(["twitterapi", 102718482], function(response) {
    console.log(response);
})
```

IDs, passed as integers, are treated as user_id. Usernames, passed as strings, are treated as part of screen_name. Both requests (if both apply) are then sent, and Twitter's API includes the results for both params in a single JSON block (see [my comment on #43](https://github.com/desmondmorris/node-twitter/issues/43#issuecomment-65135196) for an example).
