### PR TITLE
Remove deprecation warning checks

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -158,10 +158,6 @@ Twitter.prototype.__request = function(method, path, params, callback) {
  * GET
  */
 Twitter.prototype.get = function(url, params, callback) {
-  if (typeof Twitter.prototype[arguments.callee.caller.name] !== 'undefined') {
-    console.warn('** Deprecated: Please use the `get` function directly ** ');
-    console.warn('** Use "client.get(\'' + url.substr(0, url.lastIndexOf('.')) + '\', callback);" instead **');
-  }
   this.__request('GET', url, params, callback);
 };
 
@@ -169,10 +165,6 @@ Twitter.prototype.get = function(url, params, callback) {
  * POST
  */
 Twitter.prototype.post = function(url, params, callback) {
-  if (typeof Twitter.prototype[arguments.callee.caller.name] !== 'undefined') {
-    console.warn('** Deprecated: Please use the `post` function directly ** ');
-    console.warn('** Use "client.post(\'' + url.substr(0, url.lastIndexOf('.')) + '\', callback);" instead **');
-  }
   this.__request('POST', url, params, callback);
 };
 


### PR DESCRIPTION
The deprecation warning checks are causing implementations to fail if they are in a "use strict" environment.  This change eliminates those checks.  This fixes desmondmorris/node-twitter#51