### PR TITLE
Streaming Api now available with both POST and GET request methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Twitter for Node.js
 
+
+This is a fork of [https://github.com/desmondmorris/node-twitter/](https://github.com/desmondmorris/node-twitter/).
+
+---
+
 An asynchronous client library for the Twitter [REST](https://dev.twitter.com/rest/public) and [Streaming](https://dev.twitter.com/streaming/overview) API's.
 
 [![wercker status](https://app.wercker.com/status/624dbe8ad011852d1e01d7dc03941fc5/s/master "wercker status")](https://app.wercker.com/project/bykey/624dbe8ad011852d1e01d7dc03941fc5) [![NPM](https://nodei.co/npm/twitter.png?mini=true)](https://nodei.co/npm/twitter/)
@@ -24,14 +29,14 @@ client.get('statuses/user_timeline', params, function(error, tweets, response) {
 
 ## Installation
 
-`npm install twitter`
+`npm install twitter-enhanced`
 
 ## Quick Start
 
 You will need valid Twitter developer credentials in the form of a set of consumer and access tokens/keys.  You can get these [here](https://apps.twitter.com/).  Do not forgot to adjust your permissions - most POST request require write permissions.
 
 ```javascript
-var Twitter = require('twitter');
+var Twitter = require('twitter-enhanced');
 ```
 
 ## For User based authentication:

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -177,10 +177,14 @@ Twitter.prototype.post = function(url, params, callback) {
 /**
  * STREAM
  */
-Twitter.prototype.stream = function (method, params, callback) {
+Twitter.prototype.stream = function (method, params, callback, http_method) {
   if (typeof params === 'function') {
     callback = params;
     params = {};
+  }
+
+  if(typeof http_method === 'undefined') {
+    http_method = 'get';
   }
 
   var base = 'stream';
@@ -191,7 +195,18 @@ Twitter.prototype.stream = function (method, params, callback) {
 
   var url = this.__buildEndpoint(method, base);
 
-  var request = this.request({ url: url, qs: params});
+  var request;
+
+  if(http_method === 'get') {
+    request = this.request({ url: url, qs: params});
+  } else {
+    // post
+    request = this.request({
+      method: 'post',
+      url: url,
+      form: params
+    });
+  }
 
   var stream = new streamparser();
   stream.destroy = function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twitter-enhanced",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Twitter API client library for node.js, enhanced with Stream API POST requests",
   "license": "MIT",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "twitter",
+  "name": "twitter-enhanced",
   "version": "1.4.0",
-  "description": "Twitter API client library for node.js",
+  "description": "Twitter API client library for node.js, enhanced with Stream API POST requests",
   "license": "MIT",
   "keywords": [
     "twitter",
     "streaming",
     "oauth"
   ],
-  "homepage": "https://github.com/desmondmorris/node-twitter",
-  "author": "Desmond Morris <hi@desmondmorris.com>",
+  "homepage": "https://github.com/gabfusi/node-twitter",
+  "author": "Gabriele Fusi",
   "repository": {
     "type": "git",
-    "url": "https://github.com/desmondmorris/node-twitter"
+    "url": "https://github.com/gabfusi/node-twitter"
   },
   "scripts": {
     "test": "npm run lint && mocha",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "deep-extend": "^0.4.1",
-    "request": "^2.72.0"
+    "request": "^2.75.0"
   },
   "devDependencies": {
     "eslint": "^2.10.0",


### PR DESCRIPTION
A post request can avoid the common 2000 characters url length limit.
It is useful if you need to request a very long list of hashtags or twitter ids.
