### PR TITLE
Implemented application-only authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ You will need valid Twitter developer credentials in the form of a set of consum
 
 ```javascript
 var Twitter = require('twitter');
+```
 
+## For User based authetication:
+
+```javascript
 var client = new Twitter({
   consumer_key: '',
   consumer_secret: '',
@@ -51,6 +55,31 @@ var client = new Twitter({
   access_token_secret: process.env.TWITTER_ACCESS_TOKEN_SECRET,
 });
 ```
+## For Application Only based authetication:
+
+You will need to fetch a bearer token from Twitter as documented [Here](https://dev.twitter.com/oauth/application-only), once you have it you can use it as follows.
+
+```javascript
+var client = new Twitter({
+  consumer_key: '',
+  consumer_secret: '',
+  bearer_token: ''
+});
+```
+
+Add your credentials accordingly.  I would use environment variables to keep your private info safe.  So something like:
+
+```javascript
+var client = new Twitter({
+  consumer_key: process.env.TWITTER_CONSUMER_KEY,
+  consumer_secret: process.env.TWITTER_CONSUMER_SECRET,
+  bearer_token: process.env.TWITTER_BEARER_TOKEN,
+});
+```
+
+NB - You will not have access to all endpoints whilst using Application Only authentication, but you will have access to higher API limits.
+
+## Requests
 
 You now have the ability to make GET and POST requests against the API via the convenience methods.
 

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -37,7 +37,6 @@ function Twitter (options) {
       }
     }
   }, options);
-  console.log(this.options);
   //Check to see if we are going to use User Authentication or Application Authetication
   if (this.options.bearer_token){
     //Ok we have a bearer token, so going with application-only auth

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -23,6 +23,7 @@ function Twitter (options) {
     consumer_secret: null,
     access_token_key: null,
     access_token_secret: null,
+    bearer_token: null,
     rest_base: 'https://api.twitter.com/1.1',
     stream_base: 'https://stream.twitter.com/1.1',
     user_stream_base: 'https://userstream.twitter.com/1.1',
@@ -32,26 +33,43 @@ function Twitter (options) {
       headers: {
         'Accept': '*/*',
         'Connection': 'close',
-        'User-Agent': 'node-twitter/' + VERSION
+        'User-Agent': 'node-twitter/' + VERSION,
       }
     }
   }, options);
-
-  // Build a request object
-  this.request = request.defaults(
-    extend(
-      // Pass the client submitted request options
-      this.options.request_options,
-      {
-        oauth: {
-          consumer_key: this.options.consumer_key,
-          consumer_secret: this.options.consumer_secret,
-          token: this.options.access_token_key,
-          token_secret: this.options.access_token_secret
+  console.log(this.options);
+  //Check to see if we are going to use User Authentication or Application Authetication
+  if (this.options.bearer_token){
+    //Ok we have a bearer token, so going with application-only auth
+    // Build a request object
+      this.request = request.defaults(
+        extend(
+          //Pass the client submitted request options
+          this.options.request_options,
+          {
+            headers: {
+              Authorization: 'Bearer ' + this.options.bearer_token
+            }
+          }
+        )
+      );
+  } else {
+      //No bearer token detected so defaulting to user auth
+      this.request = request.defaults(
+      extend(
+        //Pass the client submitted request options
+        this.options.request_options,
+        {
+          oauth: {
+            consumer_key: this.options.consumer_key,
+            consumer_secret: this.options.consumer_key,
+            token: this.options.access_token_key,
+            token_secret: this.options.access_token_secret
+          }
         }
-      }
-    )
-  );
+      )
+    );
+  }
 }
 
 Twitter.prototype.__buildEndpoint = function(path, base) {

--- a/test/twitter.js
+++ b/test/twitter.js
@@ -19,6 +19,7 @@ describe('Twitter', function() {
           consumer_secret: null,
           access_token_key: null,
           access_token_secret: null,
+          bearer_token: null,
           rest_base: 'https://api.twitter.com/1.1',
           stream_base: 'https://stream.twitter.com/1.1',
           user_stream_base: 'https://userstream.twitter.com/1.1',


### PR DESCRIPTION
Ok this is my first Pull Request, and i'm also pretty new at Javascript so apologies for anything that's incorrect!

I needed application-only authentication for an application i am creating to access the higher rate limits and couldn't find anything up to date that did it so this is an attempt at that.

All i have done is added a function that looks to see if a bearer token has been supplied, if so it sets it in the header and stops the user OAuth tokens being set. If no bearer token is found everything should work as before.

The user still needs to actually generate the token externally just as they would with the user token.

Tested and seems to be working for me.