### PR TITLE
handle url.protocol on older versions of node

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -65,7 +65,7 @@ Twitter.prototype.__buildEndpoint = function(path, base) {
   };
   var endpoint = (bases.hasOwnProperty(base)) ? bases[base] : bases.rest;
 
-  if (url.parse(path).protocol !== null) {
+  if (url.parse(path).protocol) {
     endpoint = path;
   }
   else {


### PR DESCRIPTION
On older versions of node, `url.parse()`does not return `url` object with` protocol` property, if a protocol not present in the url string.

The condition `url.parse(path).protocol !== null` will always be true in those environments.
