### PR TITLE
Handle 420 status code from stream API

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -194,54 +194,93 @@ Twitter.prototype.post = function(url, params, callback) {
 /**
  * STREAM
  */
-Twitter.prototype.stream = function (method, params, callback) {
-  if (typeof params === 'function') {
-    callback = params;
-    params = {};
-  }
+Twitter.prototype.stream = (function () {
+  var savedParams = {}; 
 
-  var base = 'stream';
+  return function(method, params, callback) {
 
-  if (method === 'user' || method === 'site') {
-    base = method + '_' + base;
-  }
+    // Use parameters from most recent call when we need to retry request
+    savedParams.method = method;
+    savedParams.params = params;
+    savedParams.callback = callback;
 
-  var url = this.__buildEndpoint(method, base);
+    if (typeof params === 'function') {
+      savedParams.callback = callback = params;
+      savedParams.params = params = {};
+    }
 
-  var request = this.request({ url: url, qs: params});
+    // Don't start new request if we're waiting for a retry
+    if (typeof savedParams.pendingTimeout !== 'undefined' && savedParams.pendingTimeout) {
+      return;
+    }
 
-  var stream = new streamparser();
-  stream.destroy = function() {
-    // FIXME: should we emit end/close on explicit destroy?
-    if ( typeof request.abort === 'function' )
-    request.abort(); // node v0.4.0
-    else
-    request.socket.destroy();
-  };
+    var base = 'stream';
 
-  request.on('response', function(response) {
-    response.on('data', function(chunk) {
-      stream.receive(chunk);
-    });
+    if (method === 'user' || method === 'site') {
+      base = method + '_' + base;
+    }
 
-    response.on('error', function(error) {
+    var url = this.__buildEndpoint(method, base);
+
+    var request = this.request({ url: url, qs: params});
+
+    var stream = new streamparser();
+    stream.destroy = function() {
+      // FIXME: should we emit end/close on explicit destroy?
+      if ( typeof request.abort === 'function' )
+        request.abort(); // node v0.4.0
+      else
+        request.socket.destroy();
+    };
+
+    (function(state, savedParams) {
+      request.on('response', function(response) {
+
+        // We've sent too many requests - cancel current request and retry in 10s
+        if (response.statusCode === 420) {
+          savedParams.pendingTimeout = true;
+          stream.destroy();
+
+          var timeout = function() {
+            savedParams.pendingTimeout = false;
+
+            // Call stream again with latest parameters
+            state.stream(
+                  savedParams.method, 
+                  savedParams.params,
+                  savedParams.callback
+                );
+          };
+
+          setTimeout(timeout, 10000);
+          return;
+        }
+
+        response.on('data', function(chunk) {
+          stream.receive(chunk);
+        });
+
+        response.on('error', function(error) {
+          stream.emit('error', error);
+        });
+
+        response.on('end', function() {
+          stream.emit('end', response);
+        });
+      });
+    })(this, savedParams);
+
+    request.on('error', function(error) {
       stream.emit('error', error);
     });
 
-    response.on('end', function() {
-      stream.emit('end', response);
-    });
-  });
+    request.end();
 
-  request.on('error', function(error) {
-    stream.emit('error', error);
-  });
-  request.end();
-
-  if ( typeof callback === 'function' ) {
-    callback(stream);
-  }
-};
+    if ( typeof callback === 'function' ) {
+      callback(stream);
+    }
+  };
+})();
 
 
 module.exports = Twitter;


### PR DESCRIPTION
I was getting an error when trying to recreate the stream request with new variables:

`SyntaxError: Unexpected token E`

This was an error originating in the JSON parser because the response was just 'Exceeded connection limit for user'. I found that this error comes along with the 420 status code (https://dev.twitter.com/streaming/overview/connecting).

The fix I added will handle the 420 response status code by ending the current request and setting a timeout to call the `stream` function again after 10 seconds. If new calls to `stream` come in during that timeout period, no new request will be created but `stream` will be called with the latest parameters when the timeout ends:

For example:

```
stream('dog') called (by client application)
420 status code (by client application) - 10s timeout
stream('cat') called - no new request created, but 'cat' parameter stored
...10 seconds later
stream('cat') called (by timeOut) because it uses the new parameter
```

Twitter actually recommends backing off for 1 minute for a 420 status code, then doubling that wait for each subsequent 420 response. I didn't find that long of a wait to be necessary, but if you would like me to I can update my implementation to behave like that.