### PR TITLE
Removes License from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,27 +145,3 @@ Originally authored by  [@technoweenie](http://github.com/technoweenie)
 Currently maintained by [@desmondmorris](http://github.com/desmondmorris)
 
 [And we cannot forget the community](https://github.com/desmondmorris/node-twitter/graphs/contributors)
-
-
-## LICENSE
-
-node-twitter: Copyright (c) 2014 Desmond Morris
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
#### What's this PR do?

Removes the License section from the README file

#### Any background context you want to provide?

A proper license file was added in #149.

#### What are the relevant tickets?

#149