### PR TITLE
Return streams immediately if no callback is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ client.post('statuses/update', {status: 'I Love Twitter'},  function(error, twee
 Using the `stream` convenience method, you to open and manipulate data via a stream piped directly from one of the streaming API's. Let's see who is talking about javascript:
 
 ```javascript
+var stream = client.stream('statuses/filter', {track: 'javascript'});
+stream.on('data', function(tweet) {
+  console.log(tweet.text);
+});
+
+stream.on('error', function(error) {
+  throw error;
+});
+
+// You can also get the stream in a callback if you prefer.
 client.stream('statuses/filter', {track: 'javascript'}, function(stream) {
   stream.on('data', function(tweet) {
     console.log(tweet.text);

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -244,6 +244,9 @@ Twitter.prototype.stream = function (method, params, callback) {
   if ( typeof callback === 'function' ) {
     callback(stream);
   }
+  else {
+    return stream;
+  }
 };
 
 


### PR DESCRIPTION
Since the stream is available right away we can return it.

Closes #128 