### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "deep-extend": "^0.4.1",
-    "request": "^2.51.0"
+    "request": "^2.72.0"
   },
   "devDependencies": {
     "eslint": "^2.10.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "twitter",
   "version": "v1.3.0",
   "description": "Twitter API client library for node.js",
-  "license" : "MIT",
+  "license": "MIT",
   "keywords": [
     "twitter",
     "streaming",
@@ -19,7 +19,7 @@
     "lint": "eslint test/*.js lib/*.js"
   },
   "dependencies": {
-    "deep-extend": "^0.3.2",
+    "deep-extend": "^0.4.1",
     "request": "^2.51.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "eslint": "^2.10.0",
-    "mocha": "^2.1.0",
+    "mocha": "^2.4.5",
     "nock": "^0.57.0"
   },
   "main": "./lib/twitter"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "eslint": "^2.10.0",
-    "jshint": "^2.6.0",
     "mocha": "^2.1.0",
     "nock": "^0.57.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "eslint": "^2.10.0",
     "mocha": "^2.4.5",
-    "nock": "^0.57.0"
+    "nock": "^8.0.0"
   },
   "main": "./lib/twitter"
 }


### PR DESCRIPTION
#### What's this PR do?

* Updates `deep-extend` from `^0.3.2` to `^0.4.1`
* Updates `request` from `^2.51.0` to `^2.51.0`
* Removes `jshint`
* Updates `mocha` from `^2.1.0` to `^2.4.5`
* Updates `nock` from `^0.57.0` to `^8.0.0`

#### Any background context you want to provide?

A bit of necessary housekeeping.

#### What are the relevant tickets?

#150 

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch