### PR TITLE
Removes conditional that sets undefined/unused stream var

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -117,11 +117,6 @@ Twitter.prototype.__request = function(method, path, params, callback) {
     delete params.base;
   }
 
-  // Stream?
-  if (base.match(/stream/)) {
-    stream = true;
-  }
-
   // Build the options to pass to our custom request object
   var options = {
     method: method.toLowerCase(),  // Request method - get || post


### PR DESCRIPTION
#### What's this PR do?

Removes the unused, un-initialized `stream` variable and the conditional around it from the `__request` prototype method.

#### Any background context you want to provide?

Not sure what this was supposed to be used for.

#### What are the relevant tickets?

#154 

#### Release Type:
- [ ] Major
- [ ] Minor
- [X] Patch