### PR TITLE
JSON support for Collection API

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -124,12 +124,17 @@ Twitter.prototype.__request = function(method, path, params, callback) {
 
   // Pass form data if post
   if (method === 'post') {
-    var formKey = 'form';
-
-    if (typeof params.media !== 'undefined') {
-      formKey = 'formData';
+    if (this.options.request_options.json) {
+      options.body = params;
     }
-    options[formKey] = params;
+    else {
+      var formKey = 'form';
+
+      if (typeof params.media !== 'undefined') {
+        formKey = 'formData';
+      }
+      options[formKey] = params;
+    }
   }
 
   this.request(options, function(error, response, data) {


### PR DESCRIPTION
Hi.

Recently, I tried to use Twitter's Collections API and found that it needed Content-Type of application/json for collections/entries/curate.
(See https://dev.twitter.com/rest/reference/post/collections/entries/curate.)

Extending your library to support application/json was quite easy and this is a patch.

Usage:

    var Twitter = require('twitter');
    
    var client = new Twitter({
        consumer_key: '',
        consumer_secret: '',
        access_token_key: '',
        access_token_secret: '',
        request_options: { json: true }
    });
 
    var params = {id: 'XXX', changes: [{ op: 'add', tweet_id: 'YYY' }]};
    client.post('collections/entries/curate', params, function(error, data, response){
        if (!error) {
            console.log(data);
        }
    });

One problem is that the API is not smart because you need to specify json type when creating a Twitter instance, so the instance can be used just for application/json type request.

I am not quite sure which is better, adding json option when instantiating and checking it in __request method, or just checking if endpoint is collections/entries/curate in __request method.