### PR TITLE
stream: do not double-emit request.end()

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -240,7 +240,6 @@ Twitter.prototype.stream = function(method, params, callback) {
   request.on('error', function(error) {
     stream.emit('error', error);
   });
-  request.end();
 
   if (typeof callback === 'function') {
     callback(stream);


### PR DESCRIPTION
In a webpack browser environment, some clean-up process will lead to a double firing of the Request.prototype.end() function in http-browserify and cause an exception (because http-browserify will attempt to call setRequestHeaders, even though the request has been sent off already).

This patch removes the double firing of end().