### PR TITLE
Add promisified return path to get() and post() if no callback given

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
     'curly': 2,
     'eqeqeq': 2,
     'max-depth': 2,
-    'max-statements': [2, 17],
+    'max-statements': [2, 20],
     'new-cap': 2,
     'no-caller': 2,
     'no-cond-assign': 2,
@@ -27,5 +27,8 @@ module.exports = {
     'space-before-function-paren': [2, 'never'],
     'strict': 2,
     'wrap-iife': [2, 'inside']
+  },
+  globals: {
+    'Promise': true
   }
 };

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -64,6 +64,9 @@ function Twitter(options) {
       authentication_options
     )
   );
+
+  // Check if Promise present
+  this.allow_promise = (typeof Promise === 'function');
 }
 
 Twitter.prototype.__buildEndpoint = function(path, base) {
@@ -98,11 +101,16 @@ Twitter.prototype.__buildEndpoint = function(path, base) {
 
 Twitter.prototype.__request = function(method, path, params, callback) {
   var base = 'rest';
+  var promise = false;
 
   // Set the callback if no params are passed
   if (typeof params === 'function') {
     callback = params;
     params = {};
+  }
+  // Return promise if no callback is passed and promises available
+  else if (callback === undefined && this.allow_promise) {
+    promise = true;
   }
 
   // Set API base
@@ -132,6 +140,48 @@ Twitter.prototype.__request = function(method, path, params, callback) {
     options[formKey] = params;
   }
 
+  // Promisified version
+  if (promise) {
+    var _this = this;
+    return new Promise(function (resolve, reject) {
+      _this.request(options, function (error, response, data) {
+        // request error
+        if (error) {
+          return reject(error);
+        }
+
+        // JSON parse error or empty strings
+        try {
+          // An empty string is a valid response
+          if (data === '') {
+            data = {};
+          }
+          else {
+            data = JSON.parse(data);
+          }
+        }
+        catch(parseError) {
+          return reject(new Error('JSON parseError with HTTP Status: ' + response.statusCode + ' ' + response.statusMessage));
+        }
+
+        // response object errors
+        // This should return an error object not an array of errors
+        if (data.errors !== undefined) {
+          return reject(data.errors);
+        }
+
+        // status code errors
+        if(response.statusCode < 200 || response.statusCode > 299) {
+          return reject(new Error('HTTP Error: ' + response.statusCode + ' ' + response.statusMessage));
+        }
+
+        // no errors
+        resolve(data);
+      });
+    });
+  }
+
+  // Callback version
   this.request(options, function(error, response, data) {
     // request error
     if (error) {

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -143,8 +143,8 @@ Twitter.prototype.__request = function(method, path, params, callback) {
   // Promisified version
   if (promise) {
     var _this = this;
-    return new Promise(function (resolve, reject) {
-      _this.request(options, function (error, response, data) {
+    return new Promise(function(resolve, reject) {
+      _this.request(options, function(error, response, data) {
         // request error
         if (error) {
           return reject(error);

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -100,8 +100,7 @@ Twitter.prototype.__buildEndpoint = function(path, base) {
 };
 
 Twitter.prototype.__request = function(method, path, params, callback) {
-  var base = 'rest';
-  var promise = false;
+  var base = 'rest', promise = false;
 
   // Set the callback if no params are passed
   if (typeof params === 'function') {


### PR DESCRIPTION
Resolves #138 for `get()` and `post()` using the dual-return approach mentioned in the issue thread. If no callback is passed, a promise is returned, to be rejected on error or resolved with the response data.

Note: unlike the callback version, the raw response is not returned, since promises only allow a single return value, and ES6 decomposition is not available on older Node versions.
