### PR TITLE
Emit PING on KeepAlive packet

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
     'curly': 2,
     'eqeqeq': 2,
     'max-depth': 2,
-    'max-statements': [2, 16],
+    'max-statements': [2, 17],
     'new-cap': 2,
     'no-caller': 2,
     'no-cond-assign': 2,

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -62,6 +62,9 @@ Parser.prototype.receive = function receive(buffer) {
         error.source = json;
         this.emit('error', error);
       }
+    } else {
+      // Keep Alive
+      this.emit('ping');
     }
   }
 };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -62,7 +62,8 @@ Parser.prototype.receive = function receive(buffer) {
         error.source = json;
         this.emit('error', error);
       }
-    } else {
+    }
+    else {
       // Keep Alive
       this.emit('ping');
     }


### PR DESCRIPTION
Improve PR's #183 and #186 using the PING method from this fork https://github.com/rneilson/node-twitter/blob/8a483ed3fcea3904536c794f1edd0149624a1416/lib/parser.js

Helps with notes in #111 when the Module drops the stream can capture/monitor the keep alive and reconnect at a program level instead of a Module level.

Work could be done to add a auto reconnect to the module itself, but doing it at program level should suffice for now
