### PR TITLE
Disables eslint in travis for versions < 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
-node_js:
-  - 6.1
-  - 4.4
-  - 0.12
-  - 0.10
+matrix:
+  include:
+    - node_js: 7
+    - node_js: 6
+    - node_js: 4
+    - node_js: 0.12
+      script: mocha
+    - node_js: 0.10
+      script: mocha


### PR DESCRIPTION
## What?
* Disables eslint in travis for versions < 4.x
* Adds 7.x to the test matrix

## Why?

Builds are failing in Travis because of eslint.  For some reason, it has decided to lint files within the node_modules directories on node 0.10 and 0.12 environments.  I could not recreate locally.  I was inspired down this path by this thread: https://github.com/postcss/postcss-plugin-boilerplate/issues/36