### PR TITLE
Add response event to stream on 200 response

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -224,6 +224,10 @@ Twitter.prototype.stream = function(method, params, callback) {
     if(response.statusCode !== 200) {
       stream.emit('error', new Error('Status Code: ' + response.statusCode));
     }
+    else {
+      stream.emit('response', response);
+    }
+
     response.on('data', function(chunk) {
       stream.receive(chunk);
     });


### PR DESCRIPTION
This is just a small little thing, but I've found it helpful for having an event to trigger, say, resolving a promise once the stream is connected.