### PR TITLE
Send media metadata in body

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -100,7 +100,7 @@ Twitter.prototype.__buildEndpoint = function(path, base) {
 };
 
 Twitter.prototype.__request = function(method, path, params, callback) {
-  var base = 'rest', promise = false;
+  var base = 'rest', promise = false, formKey = 'form';
 
   // Set the callback if no params are passed
   if (typeof params === 'function') {
@@ -131,10 +131,11 @@ Twitter.prototype.__request = function(method, path, params, callback) {
 
   // Pass form data if post
   if (method === 'post') {
-    var formKey = 'form';
-
     if (typeof params.media !== 'undefined') {
       formKey = 'formData';
+    }
+    else if (path.indexOf('media/metadata') === 0) {
+      formKey = 'body';
     }
     options[formKey] = params;
   }


### PR DESCRIPTION
Per [the docs](https://dev.twitter.com/rest/reference/post/media/metadata/create):

> Requests should be HTTP POST with a JSON content body

Closes #217