### PR TITLE
Allow post data method modification

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -29,6 +29,7 @@ function Twitter(options) {
     user_stream_base: 'https://userstream.twitter.com/1.1',
     site_stream_base: 'https://sitestream.twitter.com/1.1',
     media_base: 'https://upload.twitter.com/1.1',
+    post_method: null,
     request_options: {
       headers: {
         Accept: '*/*',
@@ -129,14 +130,10 @@ Twitter.prototype.__request = function(method, path, params, callback) {
     options.qs = params;
   }
 
-  // Pass form data if post
+  // Pass data if post
   if (method === 'post') {
-    var formKey = 'form';
-
-    if (typeof params.media !== 'undefined') {
-      formKey = 'formData';
-    }
-    options[formKey] = params;
+    var post_method = this.options.post_method ? this.options.post_method : (params.media ? 'formData' : 'form');
+    options[post_method] = params;
   }
 
   // Promisified version

--- a/test/twitter.js
+++ b/test/twitter.js
@@ -21,6 +21,7 @@ describe('Twitter', function() {
         user_stream_base: 'https://userstream.twitter.com/1.1',
         site_stream_base: 'https://sitestream.twitter.com/1.1',
         media_base: 'https://upload.twitter.com/1.1',
+        post_method: null,
         request_options: {
           headers: {
             'Accept': '*/*',


### PR DESCRIPTION
Some Twitter POST requests need a JSON POST body. (Like [the new direct_messages endpoint](https://dev.twitter.com/rest/reference/post/direct_messages/events/new))
As node-twitter constrain us to use `form` or `form-data` POST method, we aren't able to use new Twitter functionalities.

This commit adds a `post_method` option in node-twitter's options which, when modified, is used to pass POST data.