### PR TITLE
Allow users to specify a full path

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -78,8 +78,9 @@ Twitter.prototype.__buildEndpoint = function(path, base) {
     'media': this.options.media_base
   };
   var endpoint = (bases.hasOwnProperty(base)) ? bases[base] : bases.rest;
-
-  if (url.parse(path).protocol) {
+  // if full url is specified we use that
+  var isFullUrl = (url.parse(path).protocol !== null);
+  if (isFullUrl) {
     endpoint = path;
   }
   else {
@@ -93,8 +94,10 @@ Twitter.prototype.__buildEndpoint = function(path, base) {
   // Remove trailing slash
   endpoint = endpoint.replace(/\/$/, '');
 
-  // Add json extension if not provided in call
-  endpoint += (path.split('.').pop() !== 'json') ? '.json' : '';
+  if(!isFullUrl) {
+    // Add json extension if not provided in call... only if a full url is not specified
+    endpoint += (path.split('.').pop() !== 'json') ? '.json' : '';
+  }
 
   return endpoint;
 };

--- a/test/twitter.js
+++ b/test/twitter.js
@@ -168,12 +168,7 @@ describe('Twitter', function() {
 
         assert.equal(
           client.__buildEndpoint(endpoint),
-          endpoint + '.json'
-        );
-
-        assert.equal(
-          client.__buildEndpoint(endpoint),
-          endpoint + '.json'
+          endpoint
         );
       });
     });


### PR DESCRIPTION
If a full url is specified the library shouldn't add a `.json` at the end. The use case for this is using the same client also for gnip (which doesn't have `.json` at the end of path)