### PR TITLE
jsonExtensionOverride

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -69,7 +69,7 @@ function Twitter(options) {
   this.allow_promise = (typeof Promise === 'function');
 }
 
-Twitter.prototype.__buildEndpoint = function(path, base) {
+Twitter.prototype.__buildEndpoint = function(path, base, jsonExtensionOverride) {
   var bases = {
     'rest': this.options.rest_base,
     'stream': this.options.stream_base,
@@ -92,11 +92,13 @@ Twitter.prototype.__buildEndpoint = function(path, base) {
 
   // Remove trailing slash
   endpoint = endpoint.replace(/\/$/, '');
-
+  if (!jsonExtensionOverride) {
+    endpoint += (path.split('.').pop() !== 'json') ? '.json' : '';
+  }
   return endpoint;
 };
 
-Twitter.prototype.__request = function(method, path, params, callback) {
+Twitter.prototype.__request = function(method, path, params, callback, jsonExtensionOverride) {
   var base = 'rest', promise = false;
 
   // Set the callback if no params are passed
@@ -118,7 +120,7 @@ Twitter.prototype.__request = function(method, path, params, callback) {
   // Build the options to pass to our custom request object
   var options = {
     method: method.toLowerCase(),  // Request method - get || post
-    url: this.__buildEndpoint(path, base) // Generate url
+    url: this.__buildEndpoint(path, base, jsonExtensionOverride) // Generate url
   };
 
   // Pass url parameters if get
@@ -226,8 +228,8 @@ Twitter.prototype.__request = function(method, path, params, callback) {
 /**
  * GET
  */
-Twitter.prototype.get = function(url, params, callback) {
-  return this.__request('get', url, params, callback);
+Twitter.prototype.get = function(url, params, callback, jsonExtensionOverride) {
+  return this.__request('get', url, params, callback, jsonExtensionOverride);
 };
 
 /**

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -93,9 +93,6 @@ Twitter.prototype.__buildEndpoint = function(path, base) {
   // Remove trailing slash
   endpoint = endpoint.replace(/\/$/, '');
 
-  // Add json extension if not provided in call
-  endpoint += (path.split('.').pop() !== 'json') ? '.json' : '';
-
   return endpoint;
 };
 


### PR DESCRIPTION
Adding .json to the request causes some calls in the Ads API to fail such as the call for for paginating.

`${adsAPIHost}/accounts/${accountId}/promoted_tweets?cursor=${body.next_cursor}`

This optional boolean on the Get path means users can override adding .json for these edge cases while retaining functionality for the other APIs.