### PR TITLE
Fix error when check parameter params of request method 

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -116,11 +116,12 @@ Twitter.prototype.__request = function(method, path, params, callback) {
   }
 
   // Set API base
-  if (typeof params.base !== 'undefined') {
-    base = params.base;
-    delete params.base;
+  if (params) {
+    if (typeof params.base !== 'undefined') {
+      base = params.base;
+      delete params.base;
+    }
   }
-
   // Build the options to pass to our custom request object
   var options = {
     method: method.toLowerCase(),  // Request method - get || post


### PR DESCRIPTION
When I called method 
`twitter.get('favorites/list')`
If I did not pass the params parameter, this function will throw error `TypeError: Cannot read property 'base' of undefined`. And I find out that you check property base of params by used this statement 
`if (typeof params.base !== 'undefined') {
      base = params.base;
      delete params.base;
    }`
It causes a error above.