### PR TITLE
Update Readme.md to extend example of posting a tweet 

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The REST API convenience methods will also return Promises if:
 If those two conditions are met, the above example becomes:
 
 ```javascript
-client.post('statuses/update', {status: 'I Love Twitter'})
+client.post('statuses/update', {status: 'I Love Twitter', screen_name: 'username'})
   .then(function (tweet) {
     console.log(tweet);
   })


### PR DESCRIPTION
In the current example of posting a tweet from an authorised user account, it is not clear where do we need to pass the username. Updated Readme to accomodate this.