### PR TITLE
Fix issue where promise-style requests throw an error if no params are passed

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -116,7 +116,7 @@ Twitter.prototype.__request = function(method, path, params, callback) {
   }
 
   // Set API base
-  if (typeof params.base !== 'undefined') {
+  if (params && typeof params.base !== 'undefined') {
     base = params.base;
     delete params.base;
   }


### PR DESCRIPTION
With callback-style requests, the `params` argument is always present whether it's actually a params object or a function. But with promise-style requests, it's possible to make a call without the `params` argument at all, so we need to check that it's defined before trying to use it.