### PR TITLE
Support for POST with JSON body

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,16 @@ client.post(path, params, callback);
 client.stream(path, params, callback);
 ```
 
+When the `post` convenience method is used to submit a JSON body, the `params` object must be structured as follows:
+
+```javascript
+{
+  json_body: {
+    // JavaSctript object to be submitted as JSON body
+  }
+}
+```
+
 ## REST API
 
 You simply need to pass the endpoint and parameters to one of convenience methods.  Take a look at the [documentation site](https://dev.twitter.com/rest/public) to reference available endpoints.
@@ -110,6 +120,28 @@ How about an example that passes parameters?  Let's  [tweet something](https://d
 client.post('statuses/update', {status: 'I Love Twitter'},  function(error, tweet, response) {
   if(error) throw error;
   console.log(tweet);  // Tweet body.
+  console.log(response);  // Raw response object.
+});
+```
+
+Example of POST with JSON body (new [direct_messages/events/new](https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/new-event) API):
+
+```javascript
+let params = {
+  json_body: {
+    event: {
+      type: 'message_create',
+      message_create: {
+        target: { recipient_id: '1234567890' },
+        message_data: { text: 'Hi there!' }
+      }
+    }
+  }
+};
+
+client.post('direct_messages/events/new', params, (error, result, response) => {
+  if (error) throw error;
+  console.log(result);  // Newly created event object.
   console.log(response);  // Raw response object.
 });
 ```

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -132,14 +132,19 @@ Twitter.prototype.__request = function(method, path, params, callback) {
     options.qs = params;
   }
 
-  // Pass form data if post
+  // Pass either form data or JSON body if post
   if (method === 'post') {
-    var formKey = 'form';
+    if (params.json_body) {
+      options.json = params.json_body;
 
-    if (typeof params.media !== 'undefined') {
-      formKey = 'formData';
+    } else {
+      var formKey = 'form';
+
+      if (typeof params.media !== 'undefined') {
+        formKey = 'formData';
+      }
+      options[formKey] = params;
     }
-    options[formKey] = params;
   }
 
   // Promisified version
@@ -158,7 +163,7 @@ Twitter.prototype.__request = function(method, path, params, callback) {
           if (data === '') {
             data = {};
           }
-          else {
+          else if (typeof data === 'string') {
             data = JSON.parse(data);
           }
         }
@@ -196,7 +201,7 @@ Twitter.prototype.__request = function(method, path, params, callback) {
       if (data === '') {
         data = {};
       }
-      else {
+      else if (typeof data === 'string') {
         data = JSON.parse(data);
       }
     }


### PR DESCRIPTION
There are multiple open issues asking support for POST requests with JSON body (as needed to use the new  [POST direct_messages/events/new](https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/new-event) API). Pull request [#230](https://github.com/desmondmorris/node-twitter/pull/230) addresses this problem, but it seems to have ended up stuck.

This pull request tries to address the problem while ensuring complete backward compatibility with any existing use the the [node-twitter](https://github.com/desmondmorris/node-twitter) library. With the updated code, when the `client.post` convenience method is used to submit a JSON body, the `params` object must be structured as follows:
```javascript
{
  json_body: {
    // JavaSctript object to be submitted as JSON body
  }
}
```
For example:
```javascript
let params = {
  json_body: {
    event: {
      type: 'message_create',
      message_create: {
        target: { recipient_id: '1234567890' },
        message_data: { text: 'Hi there!' }
      }
    }
  }
};

client.post('direct_messages/events/new', params, (error, result, response) => {
  if (error) throw error;
  console.log(result);  // Newly created event object.
  console.log(response);  // Raw response object.
});
```
Note that when the POST request is passed to the [request](https://www.npmjs.com/package/request) module with the indication to use JSON body, the [request](https://www.npmjs.com/package/request) module automatically parses the response body. Therefore, the code has been updated to avoid attempting to parse the data returned by the [request](https://www.npmjs.com/package/request) module if the data is an object rather than a string.