### PR TITLE
Add support for DELETE methods.

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -128,7 +128,7 @@ Twitter.prototype.__request = function(method, path, params, callback) {
   };
 
   // Pass url parameters if get
-  if (method === 'get') {
+  if (method === 'get' || method === 'delete') {
     options.qs = params;
   }
 
@@ -241,6 +241,13 @@ Twitter.prototype.get = function(url, params, callback) {
  */
 Twitter.prototype.post = function(url, params, callback) {
   return this.__request('post', url, params, callback);
+};
+
+/**
+ * DELETE
+ */
+Twitter.prototype.delete = function(url, params, callback) {
+  return this.__request('delete', url, params, callback);
 };
 
 /**


### PR DESCRIPTION
Deleting direct messages for example requires sending a DELETE request: https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/delete-message-event.